### PR TITLE
Handle GA case

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,26 +13,23 @@ supporting static IPs for application load balancers. See
 for more details.)
 
 ## Config File
-The config uses the following format:
+The config uses the following format (JSON also supported):
 ````
-{
-    "apps": [{
-        "name": "app_name",
-        "additionalText": "this shows up beside the app name"
-        "altname": "alt_name"
-        "config": [{
-            "dnsname": "example.com",
-            "region": "us-west-1",
-            "exclusions": [],
-            "inclusions": {
-              "dnsname": "example-2.com",
-              "ip_list": []
-            }
-            "show_eip": true,
-            "show_lb_ip": true,
-            "show_inst_ip": true
-        }]
-    }]
+apps:
+  - name: app_name
+    additionalText: this shows up beside the app name
+    altname: alt_name
+    config:
+      - dnsname: example.com
+        region: us-west-1
+        exclusions: []
+        inclusions:
+          dns_list:
+            - example-2.com
+          ip_list: []
+        show_eip: true
+        show_lb_ip: true
+        show_inst_ip: true
 }
 ````
 
@@ -44,11 +41,12 @@ The config uses the following format:
 **dnsname:** The domain name.   
 **exclusions:** List of IPs to be excluded from the result.   
 **[inclusions]:** This is an optional dictionary with elements to query for IPs.   
-**[dnsname]:** This is an optional variable that the user can use to specify a domain to query for IPs.   
+**[dns_list]:** This is an optional list of domains to query for IPs.
 **[ip_list]:** This is an optional list of IPs to include.   
 **show_eip:** Whether or not to show the list of Elastic IPs associated with your account.   
 **show_lb_ip:** Whether or not to show the IPs associated with the load balancer.   
-**show_inst_up:** Whether or not to show the IPs of the currently running instances.   
+**show_inst_up:** Whether or not to show the IPs of the currently running instances.
+**[lb_names]:** If the dnsname above resolves directly to IP(s), supply the load balancer name(s) if show_inst_ip is set to true
 
 An example URL would be: localhost:5000/app .   
 The URL can take up to 2 query strings, verbose and region.    

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The config uses the following format (JSON also supported):
 ````
 apps:
   - name: app_name
+    hidden: true
     additionalText: this shows up beside the app name
     altname: alt_name
     config:
@@ -34,9 +35,10 @@ apps:
 ````
 
 **apps:** An array of apps.   
-**name:** This is the name the browser will need to point to in order to access this app's IP list.   
-**[altname:]** This is an *optional* variable that the user can use to create a optional url webpage with same info (for backward compatibility purpose).   
-**[additionalText:]** This is an *optional* variable that the user can use to add additional text beside the app name.   
+**name:** This is the name the browser will need to point to in order to access this app's IP list.
+**[hidden:]** This is an *optional* parameter the user can specify to create a hidden link.
+**[altname:]** This is an *optional* parameter that the user can use to create a optional url webpage with same info (for backward compatibility purpose).
+**[additionalText:]** This is an *optional* parameter that the user can use to add additional text beside the app name.
 **config:** An array of variables needed.   
 **dnsname:** The domain name.   
 **exclusions:** List of IPs to be excluded from the result.   

--- a/app/awslib.py
+++ b/app/awslib.py
@@ -100,7 +100,7 @@ def _get_v2_lbs(elb_client, next_marker=None):
 
     if 'NextMarker' in query_result:
         result.extend(query_result['LoadBalancers'])
-        result.extend(_get_v1_lbs(elb_client, next_marker=query_result['NextMarker']))
+        result.extend(_get_v2_lbs(elb_client, next_marker=query_result['NextMarker']))
     else:
         result.extend(query_result['LoadBalancers'])
     return result
@@ -169,37 +169,40 @@ def _get_instances_public_ip(ec2_client, instances):
 
 # IPs of running instances
 def list_instance_ips(lb_name, region):
-    print ("Getting IPs for instances behind load balancer %s..." % lb_name)
+    print ("Looking for instances behind load balancer %s..." % lb_name)
     instance_ips = []
     lb_found = False
     print ("Connecting to ec2 elb v1...")
     elbv1 = boto3.client('elb', region_name=region)
     if elbv1:
-        print ("Connected!")
+        # print ("Connected!")
         print ("Retrieving classic load balancers...")
         v1_lbs = _get_v1_lbs(elbv1, next_marker=None)
         ec2_client = boto3.client('ec2', region_name=region)
         if ec2_client:
             for lb in v1_lbs:
                 if lb_name in lb['LoadBalancerName'].lower():
-                    lb_found = True
+                    print("Found the load balancer")
                     print ("Processing instances for ELB %s" % lb['LoadBalancerName'])
                     instances = [inst['InstanceId'] for inst in lb['Instances']]
                     print ("Instances discovered: %s" % str(instances))
                     if instances:
                         instance_ips.extend(_get_instances_public_ip(ec2_client, instances))
+                    lb_found = True
+                    break
             # Only look at v2 load balancers if we haven't already found the load balancer above
             if not lb_found:
                 print("Didn't find the load balancer in the list of classic load balancers")
                 print ("Connecting to ec2 elb v2...")
                 elbv2 = boto3.client('elbv2', region_name=region)
                 if elbv2:
-                    print ("Connected!")
+                    # print ("Connected!")
                     print ("Retrieving V2 load balancers...")
                     v2_lbs = _get_v2_lbs(elbv2, next_marker=None)
                     for lb in v2_lbs:
                         if lb_name in lb['LoadBalancerName'].lower():
-                            print ("Processing target groups for ELB %s" % lb['LoadBalancerName'])
+                            print("Found the load balancer")
+                            print ("Processing target groups for %s" % lb['LoadBalancerName'])
                             lb_arn = lb['LoadBalancerArn']
                             # Get the target groups for this load balancer
                             response = elbv2.describe_target_groups(LoadBalancerArn=lb_arn)
@@ -213,6 +216,10 @@ def list_instance_ips(lb_name, region):
                                     instances = _get_instances_for_target_group(elbv2, tg_arn, target_type, region)
                                     if instances:
                                         instance_ips.extend(_get_instances_public_ip(ec2_client, instances))
+                            lb_found = True
+                            break
+                    if not lb_found:
+                        print("Didn't find the load balancer in the list of application/network load balancers")
                 else:
                     print("ERROR: Failed to connect to ELBV2")
         else:

--- a/app/awslib.py
+++ b/app/awslib.py
@@ -11,7 +11,8 @@ def list_eips(region, filter):
     print ("Connecting to ec2...")
     client = boto3.client('ec2', region_name=region)
     if client:
-        print("Connected!")
+        # print("Connected!")
+        print("Getting all EIPs in region %s" % region)
         addresses_dict = client.describe_addresses()
         for eip_dict in addresses_dict['Addresses']:
             if eip_dict['PublicIp'] not in filter:
@@ -32,7 +33,7 @@ def get_active_balancer(dns_name, region):
     print ("Connecting to route53...")
     rconn = boto3.client('route53', region_name=region)
     if rconn:
-        print("Connected!")
+        # print("Connected!")
         zones = rconn.list_hosted_zones()
         chosen_zone = None
         print ("Looking up zone ID...")

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,7 +10,13 @@
             <li><a href="{{request.path}}{{app.name}}">{{app.name}}</a>{% if app.additionalText != null %} {{app.additionalText}}{% endif %}</li>
         {% endfor %}
 
-        <!--Below URL Links will be deprecated in the near future. Please use above URLs instead. -->
+        <!-- Hidden Links -->
+
+        {% for app in hidden %}
+            <li style="display:none;><a href="{{request.path}}{{app.name}}">{{app.name}}</a></li>
+        {% endfor %}
+
+        <!-- Below URL Links will be deprecated in the near future. Please use above URLs instead. -->
 
         {% for app in altapps %}
             <li style="display:none;><a href="{{request.path}}{{app.name}}">{{app.name}}</a></li>

--- a/app/views.py
+++ b/app/views.py
@@ -51,24 +51,32 @@ def handle_index():
         data = yaml.safe_load(config_data)
 
     app_data = []
+    hidden_apps = []
+    alt_apps = []
     for app in data['apps']:
-        app_info = {}
-        app_info['name'] = app['name']
-        app_info['additionalText'] = ''
-        if app.get('additionalText'):
-            app_info['additionalText'] = app['additionalText']
-        app_data.append(app_info)
-
-    # creating altname list for to be deprecated url links
-    altapps=[]
-    for app in data['apps']:
+        # altname list for deprecated url links
         if app.get('altname'):
             app_info = {}
             app_info['name'] = app['altname']
             app_info['additionalText'] = ''
-            altapps.append(app_info)
+            alt_apps.append(app_info)
+        if app.get('hidden'):
+            print('Found hidden app: %s' % app['name'])
+            app_info = {}
+            app_info['name'] = app['name']
+            app_info['additionalText'] = ''
+            if app.get('additionalText'):
+                app_info['additionalText'] = app['additionalText']
+            hidden_apps.append(app_info)
+        else:
+            app_info = {}
+            app_info['name'] = app['name']
+            app_info['additionalText'] = ''
+            if app.get('additionalText'):
+                app_info['additionalText'] = app['additionalText']
+            app_data.append(app_info)
 
-    return render_template("index.html", apps=app_data, altapps=altapps)
+    return render_template("index.html", apps=app_data, altapps=alt_apps, hidden=hidden_apps)
 
 
 @app.route('/healthcheck')

--- a/app/views.py
+++ b/app/views.py
@@ -156,10 +156,6 @@ def handle_app(appname):
                                 ret[item['Name']]['all_ips'] = awslib.get_records_from_zone(item['HostedZoneId'], item['Pattern'])
                             break
 
-                        dnsname = config['dnsname']
-                        # bs_app = None
-                        # if 'beanstalk_app_name' in config:
-                        #     bs_app = config['beanstalk_app_name']
                         region = config['region']
 
                         # only run next section if region equal chosen_region
@@ -167,28 +163,23 @@ def handle_app(appname):
                             if chosen_region != region:
                                 continue
 
-                        inclusions = None
-                        if config.get('inclusions') != None:
-                            inclusions = config['inclusions']
-                        exclusions = config['exclusions']
+                        dnsname = config.get('dnsname')
+                        inclusions = config.get('inclusions')
+                        exclusions = config.get('exclusions')
                         eip_check = config.get('show_eip')
                         lb_check = config.get('show_lb_ip')
                         inst_check = config.get('show_inst_ip')
-                        if ret.get(region) == None:
+                        if not ret.get(region):
                             ret[region] = {}
-                        lb_name = awslib.get_active_balancer(dnsname, region)
 
-                        if not lb_name:
-                            print('ERROR: Unable to determine LB name - will NOT be able to get instance IPs')
-
-                        if ret[region].get('all_ips') == None:
+                        if not ret[region].get('all_ips'):
                             ret[region]['all_ips'] = []
 
-                        if not eip_check == None:
+                        if eip_check:
                             eips = awslib.list_eips(region, filter=exclusions)
                             # verbose only makes sense if we're not getting ALL EIPs
                             if verbose:
-                                if ret[region].get('eips') == None:
+                                if not ret[region].get('eips'):
                                     ret[region]['eips'] = eips
                                 else:
                                     ret[region]['eips'].extend(eips)
@@ -196,11 +187,11 @@ def handle_app(appname):
                             if eip_check:
                                 ret[region]['all_ips'].extend(eips)
 
-                        if not lb_check == None:
+                        if lb_check:
                             elb = awslib.list_balancer_ips(dnsname)
 
                             if verbose:
-                                if ret[region].get('elb') == None:
+                                if not ret[region].get('elb'):
                                     ret[region]['elb'] = elb
                                 else:
                                     ret[region]['elb'].extend(elb)
@@ -208,33 +199,41 @@ def handle_app(appname):
                             if lb_check:
                                 ret[region]['all_ips'].extend(elb)
 
-                        if not inst_check == None:
-                            if lb_name:
-                                inst_ips = awslib.list_instance_ips(lb_name, region)
-                                if verbose:
-                                    if ret[region].get('instance_ips') == None:
-                                        ret[region]['instance_ips'] = inst_ips
-                                    else:
-                                        ret[region]['instance_ips'].extend(inst_ips)
+                        if inst_check:
+                            lb_names = config.get('lb_names')
+                            lb_name = None
+                            if not lb_names:
+                                lb_name = awslib.get_active_balancer(dnsname, region)
 
-                                if inst_check:
-                                    ret[region]['all_ips'].extend(inst_ips)
+                            if not lb_name and not lb_names:
+                                print('ERROR: Unable to determine LB name(s) - cannot get instance IPs')
                             else:
-                                print('Asked to get instances behind load balancer, but cannot determine LB name')
+                                if not lb_names:
+                                    lb_names = [lb_name]
+                                for lb in lb_names:
+                                    inst_ips = awslib.list_instance_ips(lb.lower(), region)
+                                    if verbose:
+                                        if not ret[region].get('instance_ips'):
+                                            ret[region]['instance_ips'] = inst_ips
+                                        else:
+                                            ret[region]['instance_ips'].extend(inst_ips)
+
+                                    if inst_check:
+                                        ret[region]['all_ips'].extend(inst_ips)
 
                         if inclusions:
                             if 'dns_list' in inclusions:
                                 for dns in inclusions['dns_list']:
                                     dns_ips = awslib.list_balancer_ips(dns)
                                     if verbose:
-                                        if ret[region].get('inclusions') == None:
+                                        if not ret[region].get('inclusions'):
                                             ret[region]['inclusions'] = dns_ips
                                         else:
                                             ret[region]['inclusions'].extend(dns_ips)
                                     ret[region]['all_ips'].extend(dns_ips)
                             if 'ip_list' in inclusions:
                                 if verbose:
-                                    if ret[region].get('inclusions') == None:
+                                    if not ret[region].get('inclusions'):
                                         ret[region]['inclusions'] = inclusions['ip_list']
                                     else:
                                         ret[region]['inclusions'].extend(inclusions['ip_list'])


### PR DESCRIPTION
In the case where a Global Accelerator is in play - the DNS name for a given app will point to a record that references IPs directly, instead of an alias to a load balancer. In this case, if we want to get the instances behind the load balancer, we need to supply the load balancer name. 

Was careful not to break backwards compatibility with the old config files.