### PR TITLE
Add new get_file_contents to awslib and use it in new S3 config

### DIFF
--- a/app/awslib.py
+++ b/app/awslib.py
@@ -2,6 +2,7 @@ import boto3
 import re
 import os
 import socket
+import json
 
 
 # List of all EIPs in the given region
@@ -244,6 +245,17 @@ def get_file(bucket_name, s3_path, local_path):
         result = True
     return result
 
+
+# Get json file contents from S3
+def get_file_contents(bucket_name, s3_path):
+    result = None
+    print ("Retrieving config file...")
+    session = boto3.session.Session()
+    s3_client = session.client('s3')
+    response = s3_client.get_object(Bucket=s3_bucket, Key=s3_key)
+    result = json.loads(response['Body'].read().decode())
+    print ("Done")
+    return result
 
 
 def get_all_records(r53_client, zone_id, start_record_name=None, start_record_type=None, start_record_identifier=None):

--- a/app/awslib.py
+++ b/app/awslib.py
@@ -252,8 +252,12 @@ def get_file_contents(bucket_name, s3_path):
     print ("Retrieving config file...")
     session = boto3.session.Session()
     s3_client = session.client('s3')
-    response = s3_client.get_object(Bucket=s3_bucket, Key=s3_key)
-    result = json.loads(response['Body'].read().decode())
+    try:
+        response = s3_client.get_object(Bucket=s3_bucket, Key=s3_key)
+        if 'Body' in response:
+            result = json.loads(response['Body'].read().decode())
+    except Exception as e:
+        print("Exception fetching S3 object" + e)
     print ("Done")
     return result
 

--- a/app/views.py
+++ b/app/views.py
@@ -173,6 +173,29 @@ def handle_app(appname):
                                     if 'ip_list' in inclusions:
                                         ret[item['Name']]['all_ips'].extend(inclusions['ip_list'])
                             break
+                        elif config.get('S3'):
+                            ret = {}
+                            for item in config['S3']:
+                                print('Getting records for %s' % item['Name'])
+                                bucket_name = item.get('bucket')
+                                object_path = item.get('objectpath')
+                                region = item.get('region')
+                                ret[item['Name']] = {}
+                                ret[item['Name']]['all_ips'] = []
+                                if bucket_name and object_path and region:
+                                    file_contents = awslib.get_file_contents(bucket_name, object_path)
+                                    region_data = file_contents.get(region)
+                                    ret[item['Name']]['all_ips'] = region_data
+                                inclusions = item.get('inclusions')
+                                if inclusions:
+                                    print('Adding inclusions from config')
+                                    if 'dns_list' in inclusions:
+                                        for dns in inclusions['dns_list']:
+                                            dns_ips = awslib.list_balancer_ips(dns)
+                                            ret[item['Name']]['all_ips'].extend(dns_ips)
+                                    if 'ip_list' in inclusions:
+                                        ret[item['Name']]['all_ips'].extend(inclusions['ip_list'])
+                            break
 
                         region = config['region']
 


### PR DESCRIPTION
Adding a new method to awslib to get the file contents of a json file from S3. There was an existing method to get the file and save it to disk, but I didn't want to do that.

Also added new handler for new S3 config section. I would have adapted the existing s3filepath config option, but I didn't want to break existing usage of it, and I didn't want to think too hard about how to use it. 🙂 